### PR TITLE
About & Skills should use image set in config.toml

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -3,7 +3,7 @@
   <section id="about" class="main special">
     <div class="container">
       {{ if eq .Site.Params.backgroundpersection true }}
-        <span class="image fit primary"><img src="images/{{ with .Site.Params.infos.picture }}{{ . }}{{ end }}" alt="" /></span>
+        <span class="image fit primary"><img src="images/{{ with .Site.Params.about.picture }}{{ . }}{{ end }}" alt="" /></span>
       {{ end }}
       <div class="content">
         <header class="major">

--- a/layouts/partials/skills.html
+++ b/layouts/partials/skills.html
@@ -2,7 +2,7 @@
   <section id="skills" class="main special">
     <div class="container">
       {{ if eq .Site.Params.backgroundpersection true }}
-        <span class="image fit primary"><img src="images/{{ with .Site.Params.infos.picture }}{{ . }}{{ end }}" alt="" /></span>
+        <span class="image fit primary"><img src="images/{{ with .Site.Params.skill_list.picture }}{{ . }}{{ end }}" alt="" /></span>
       {{ end }}
       <div class="content">
         <header class="major">


### PR DESCRIPTION
About and Skills sections were ignoring the background image they were
set to use in config.toml instead all sharing the image set for the Info
section. Adjusts About.html and skills.html partials to correctly use
the background images set in config.toml